### PR TITLE
Remove the restriction on schema type. 

### DIFF
--- a/lib/valid-schema.js
+++ b/lib/valid-schema.js
@@ -263,7 +263,7 @@ function validateSchema(schema, names) {
 	validateArray(schema, names);
 	validateItem(schema, names);
 	// defaults are applied last after schema is validated
-	validateDefault(schema, names)
+	validateDefault(schema, names);
 }
 
 module.exports = function(schema) {
@@ -279,9 +279,6 @@ module.exports = function(schema) {
 		throw new Error('Schema: \'type\' is required');
 	}
 	assertType(schema, 'type', 'string', []);
-	if (schema.type !== 'object' && schema.type !== 'array') {
-		throw new Error('Schema: \'type\' is \'' + schema.type + '\' when it should be either \'object\' or \'array\'');
-	}
 
 	validateSchema(schema, []);
 };

--- a/test/schema-basic-test.js
+++ b/test/schema-basic-test.js
@@ -32,7 +32,6 @@ vows.describe('Schema Basic').addBatch({
 	'when schema is not an object': schemaShouldBeInvalid(schemaNotAnObject, { errMsg: 'Schema is a string when it should be an object' }),
 	'when type attribue is missing': schemaShouldBeInvalid(schemaWithoutType, { errMsg: 'Schema: \'type\' is required' }),
 	'when type attribute is not a string': schemaShouldBeInvalid(schemaInvalidType, { errMsg: 'Schema: \'type\' attribute is an integer when it should be a string' }),
-	'when type attribute is neither \'object\' nor \'array\'': schemaShouldBeInvalid(schemaInappropriateType, { errMsg: 'Schema: \'type\' is \'string\' when it should be either \'object\' or \'array\'' }),
 	'when type attribute is \'object\'': schemaShouldBeValid(schemaEmptyObject),
 	'when type attribute is \'array\'': schemaShouldBeValid(schemaEmptyArray)
 }).export(module);


### PR DESCRIPTION
This follows discussion #12.

The validation of the schema itself restricted the type of the root
object of the schema to an 'object' or an 'array'. This means that
the following schema would be rejected:

``` javascript
  {
    type: 'null',
    description: 'Nothing is returned.'
  }
```

This fix removes this limitation.

Also updated the test suite following the change in requirement
for the root type of a schema.

(Also added a semi-colon missing at the end of a line...)
