### PR TITLE
Update date-time format acceptance criteria.

### DIFF
--- a/lib/formats.js
+++ b/lib/formats.js
@@ -35,7 +35,7 @@ function validateFormatPhone(obj) {
 var formats = {
 	'date-time': { // ISO 8601 (YYYY-MM-DDThh:mm:ssZ in UTC time)
 		types: ['string'],
-		regex: /^\d{4}-\d{2}-\d{2}T[0-2]\d:[0-5]\d:[0-5]\dZ$/
+		regex: /^\d{4}-\d{2}-\d{2}T[0-2]\d:[0-5]\d:[0-5]\d(\.\d+)?Z$/
 	},
 	'date': { // YYYY-MM-DD
 		types: ['string'],


### PR DESCRIPTION
According to ISO8601 spec (http://en.wikipedia.org/wiki/ISO_8601#Times),
the time can include fractions.

The JSON schema spec ( draft 3 ) recommends but does not force the
following ISO8601 format: YYYY-MM-DDThh:mm:ssZ.

Since a javascript Date object includes the milliseconds when converted
into a string with method toISOString(), I thought easier to accept the
string with the milliseconds in the JSON Schema. The code was modified
to accept but not force the presence of a 'dot' and then an unspecified
number of digits representing the fraction of a second.

I ran the test suite and nothing failed.
