### PR TITLE
Add sanitize attribute to clean object

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ If the JSON object does not conform to the schema an error will be thrown (or re
 
 The functions stops after encountering an error. It does not return multiple errors.
 The function return a JSON object.
-Be aware that the input JSON object may be edited _in-place_ if the _default_ or _sanitize_ attribute is used.
+Be aware that the input JSON object may be edited _in-place_ if the _default_ attribute is used or when _additionalProperties_ attribute is defined by 'remove'.
 
 ### Errors
 
@@ -244,6 +244,7 @@ It can take one of two forms:
 
 * Schema - all the additional properties must be valid against the schema.
 * False - additional properties are not allowed.
+* 'remove' - remove all non-matching properties from original JSON object.
 
 Example:
 
@@ -260,15 +261,6 @@ Example:
     }
 
 The default is an empty schema, which allows any value for additional properties.
-
-### sanitize
-
-Applies only to instances of type `'object'`.
-
-Filters an non-matching properties and deletes from the object. Sanitize looks like additionalProperties, but it doesn't throws an error.
-If the object contains attributes that are not found in schema, "sanitize" will remove them from the object.
-
-`sanitize: true`
 
 ### dependencies
 

--- a/lib/valid-object.js
+++ b/lib/valid-object.js
@@ -216,6 +216,9 @@ function validateObject(obj, schema, names) {
 
 	if (schema.additionalProperties !== undefined) {
 		for (property in obj) {
+			if (schema.additionalProperties === 'remove' && schema.properties !== undefined && !(property in schema.properties)) {
+				delete obj[property];
+			}
 			if (schema.properties !== undefined && property in schema.properties) {
 				continue;
 			}
@@ -227,14 +230,6 @@ function validateObject(obj, schema, names) {
 				throw new Error('JSON object' + getName(names.concat([property])) + ' is not explicitly defined and therefore not allowed');
 			}
 			obj[property] = validateSchema(obj[property], schema.additionalProperties, names.concat([property]));
-		}
-	}
-
-	if (schema.sanitize !== undefined) {
-		for (property in obj) {
-			if (schema.properties !== undefined && !(property in schema.properties)) {
-				delete obj[property];
-			}
 		}
 	}
 

--- a/lib/valid-schema.js
+++ b/lib/valid-schema.js
@@ -171,6 +171,8 @@ function validateObject(schema, names) {
 	if (schema.additionalProperties !== undefined) {
 		if (schema.additionalProperties === false) {
 			// ok
+		} else if (schema.additionalProperties === 'remove') {
+			//ok
 		} else if (!isOfType(schema.additionalProperties, 'object')) {
 			throwInvalidType(names, '\'additionalProperties\' attribute', schema.additionalProperties, 'either an object (schema) or false');
 		} else {

--- a/test/common.js
+++ b/test/common.js
@@ -98,7 +98,7 @@ exports.objectShouldBeInvalid = function (obj, schemaDef, options) {
 	return context;
 };
 
-exports.objectShouldBeSanitize = function (obj, schemaDef, objNested, options) {
+exports.objectShouldBeEquals = function (obj, objNested, schemaDef, options) {
 	var context = {
 		topic: function () {
 			var schema = createSchema(schemaDef);

--- a/test/object-object-test.js
+++ b/test/object-object-test.js
@@ -5,7 +5,7 @@ var vows = require('vows');
 var common = require('./common'),
 	objectShouldBeValid = common.objectShouldBeValid,
 	objectShouldBeInvalid = common.objectShouldBeInvalid,
-	objectShouldBeSanitize = common.objectShouldBeSanitize;
+	objectShouldBeEquals = common.objectShouldBeEquals;
 
 var objNested = {
 	str: 'top',
@@ -109,12 +109,13 @@ var objAdditionalArray = {
 	extra: [42]
 };
 
-var objSanitize = {
+var objAdditionalPropertiesRemove = {
 	str: 'hi',
-	extra: 'discard data'
+	extra: 'discard data',
+	other: 'discard too'
 };
 
-var objNestedSanitize = {
+var objNestedAdditionalPropertiesRemove = {
 	str: 'hi'
 };
 
@@ -140,12 +141,12 @@ var schemaAdditionalPropertiesInteger = {
 	additionalProperties: { type: 'integer' }
 };
 
-var schemaSanitize = {
+var schemaAdditionalPropertiesRemove = {
 	type: 'object',
 	properties: {
 		str: { type: 'string' }
 	},
-	sanitize: true
+	additionalProperties: 'remove'
 };
 
 vows.describe('Object Object').addBatch({
@@ -158,5 +159,5 @@ vows.describe('Object Object').addBatch({
 	'when no additional properties is not respected': objectShouldBeInvalid(objAdditionalInteger, schemaNoAdditionalProperties, { errMsg: 'JSON object property \'extra\' is not explicitly defined and therefore not allowed' }),
 	'when additional property is correct type': objectShouldBeValid(objAdditionalInteger, schemaAdditionalPropertiesInteger),
 	'when additional property is wrong type': objectShouldBeInvalid(objAdditionalArray, schemaAdditionalPropertiesInteger, { errMsg: 'JSON object property \'extra\' is an array when it should be an integer' }),
-	'when sanitize is respected': objectShouldBeSanitize(objSanitize, schemaSanitize, objNestedSanitize)
+	'when additional property remove is respected': objectShouldBeEquals(objAdditionalPropertiesRemove, objNestedAdditionalPropertiesRemove, schemaAdditionalPropertiesRemove)
 }).export(module);


### PR DESCRIPTION
Cleans object, removing non-matching properties.

See bellow:

```
// Schema
{
   str: { type: 'string' },
   sanitize: true
}
```

```
// Object
{
   str: 'hi',
   extra: 'unimportant data, discard this',
   extra1: 'discard this'
}
```

```
// Result object (after validate):
{
   str: 'hi'
}
```

```
// Getting result object
newObject = schema.validate(Object);

// or
schema.validate(Object, function(err, obj) {
   newObject = obj;
});
```
