### PR TITLE
Add 'creditcard' in available formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -458,6 +458,8 @@ Example: `'192.168.1.1'`.
 Example: `'2001:0db8:85a3:0042:0000:8a2e:0370:7334'`.
 * host-name - A string containing a host-name.
 Example: `'github.com'`.
+* creditcard - A string containing a valid credit card number (check using Luhn algorithm).
+Example: `'1234567890123456'`.
 
 Note: Unknown formats are silently ignored.
 

--- a/lib/formats.js
+++ b/lib/formats.js
@@ -32,6 +32,21 @@ function validateFormatPhone(obj) {
 	return obj.match(phoneReNational) || obj.match(phoneReInternational);
 }
 
+// https://gist.github.com/2134376
+// Phil Green (ShirtlessKirk)
+function validateCreditCard(obj) {
+	var len = obj.length,
+        mul = 0,
+        prodArr = [[0, 1, 2, 3, 4, 5, 6, 7, 8, 9], [0, 2, 4, 6, 8, 1, 3, 5, 7, 9]],
+        sum = 0;
+
+    while (len--) {
+        sum += prodArr[mul][parseInt(obj.charAt(len), 10)];
+        mul ^= 1;
+    }
+    return sum % 10 === 0 && sum > 0;
+}
+
 var formats = {
 	'date-time': { // ISO 8601 (YYYY-MM-DDThh:mm:ssZ in UTC time)
 		types: ['string'],
@@ -88,6 +103,10 @@ var formats = {
 	'host-name': {
 		types: ['string'],
 		regex: /^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])$/
+	},
+	'creditcard': {
+		types: ['string'],
+		func: validateCreditCard
 	}
 };
 

--- a/test/object-format-test.js
+++ b/test/object-format-test.js
@@ -138,6 +138,14 @@ var objInvalidHost = {
 	host: '2012-11-06T09:13:24Z'
 };
 
+var objCreditCard = {
+	ccNumber: '4563960122001999'
+};
+
+var objInvalidCreditCard = {
+	ccNumber: '4563960122001000'
+};
+
 var schemaDateTime = {
 	type: 'object',
 	properties: {
@@ -292,6 +300,17 @@ var schemaHost = {
 	}
 };
 
+var schemaCreditCard = {
+	type: 'object',
+	properties: {
+		ccNumber: {
+			type: 'string',
+			format: 'creditcard',
+			required: true
+		}
+	}
+};
+
 var objProprietary = {
 	prop: 'la la la'
 };
@@ -342,5 +361,7 @@ vows.describe('Object Format').addBatch({
 	'when trying to pass a host-name for an ipv6': objectShouldBeInvalid(objInvalidIp6, schemaIp6, { errMsg: 'JSON object property \'ip6\' does not conform to the \'ipv6\' format' }),
 	'when a host-name is passed for a host-name': objectShouldBeValid(objHost, schemaHost),
 	'when trying to pass a date-time for a host-name': objectShouldBeInvalid(objInvalidHost, schemaHost, { errMsg: 'JSON object property \'host\' does not conform to the \'host-name\' format' }),
-	'when format is unknown': objectShouldBeValid(objProprietary, schemaProprietary)
+	'when format is unknown': objectShouldBeValid(objProprietary, schemaProprietary),
+	'when a valid creditcard number is passed for a creditcard': objectShouldBeValid(objCreditCard, schemaCreditCard),
+	'when a invalid creditcard number is passed for a creditcard': objectShouldBeInvalid(objInvalidCreditCard, schemaCreditCard),
 }).export(module);


### PR DESCRIPTION
Add a creditcard format.

This feature checks if a string contains a valid credit card number.
