### PR TITLE
Clear object using new form to additionalProperties

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,8 +75,8 @@ This function gets a JSON object and validates it against the schema.
 If the JSON object does not conform to the schema an error will be thrown (or returned, see _Synchronous/Asynchronous_ below).
 
 The functions stops after encountering an error. It does not return multiple errors.
-The function does not return a value.
-Be aware that the input JSON object may be edited _in-place_ if the _default_ attribute is used.
+The function return a JSON object.
+Be aware that the input JSON object may be edited _in-place_ if the _default_ or _sanitize_ attribute is used.
 
 ### Errors
 
@@ -92,7 +92,7 @@ For example: "Schema property 'num': 'exclusiveMaximum' attribute is a number wh
 _Schema.validate_ can be called in two ways, to suit your needs:
 
 * Synchronously - as in the example above, with one parameter.
-As already stated, it returns nothing if the object checks out. Otherwise it throws an error.
+As already stated, it returns JSON object if the object checks out. Otherwise it throws an error.
 * Asynchronously - by providing a 2nd parameter: a callback function.
 The callback function gets two arguments: error and result (the original JSON object, which may be modified).
 
@@ -260,6 +260,15 @@ Example:
     }
 
 The default is an empty schema, which allows any value for additional properties.
+
+### sanitize
+
+Applies only to instances of type `'object'`.
+
+Filters an non-matching properties and deletes from the object. Sanitize looks like additionalProperties, but it doesn't throws an error.
+If the object contains attributes that are not found in schema, "sanitize" will remove them from the object.
+
+`sanitize: true`
 
 ### dependencies
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ If the JSON object does not conform to the schema an error will be thrown (or re
 
 The functions stops after encountering an error. It does not return multiple errors.
 The function return a JSON object.
-Be aware that the input JSON object may be edited _in-place_ if the _default_ or _sanitize_ attribute is used.
+Be aware that the input JSON object may be edited _in-place_ if the _default_ attribute is used or when _additionalProperties_ attribute is defined by 'remove'.
 
 ### Errors
 
@@ -244,6 +244,7 @@ It can take one of two forms:
 
 * Schema - all the additional properties must be valid against the schema.
 * False - additional properties are not allowed.
+* 'remove' - remove all non-matching properties from original JSON object.
 
 Example:
 
@@ -260,15 +261,6 @@ Example:
     }
 
 The default is an empty schema, which allows any value for additional properties.
-
-### sanitize
-
-Applies only to instances of type `'object'`.
-
-Filters an non-matching properties and deletes from the object. Sanitize looks like additionalProperties, but it doesn't throws an error.
-If the object contains attributes that are not found in schema, "sanitize" will remove them from the object.
-
-`sanitize: true`
 
 ### dependencies
 

--- a/lib/json-gate.js
+++ b/lib/json-gate.js
@@ -6,7 +6,7 @@ var Schema = function(schema) {
 	validateSchema(schema);
 
 	this.validate = function(obj, done) {
-		validateObject(obj, schema, done);
+		return validateObject(obj, schema, done);
 	}
 }
 

--- a/lib/valid-object.js
+++ b/lib/valid-object.js
@@ -371,17 +371,17 @@ function validateSchema(obj, schema, names) {
 module.exports = function(obj, schema, done) {
 	try {
 		validateSchema(obj, schema, []);
-
-		if (done) {
-			done(null, obj);
-		} else {
-			return obj;
-		}
 	} catch(err) {
 		if (done) {
 			done(err);
 		} else {
 			throw err;
 		}
+	}
+	
+	if (done) {
+		done(null, obj);
+	} else {
+		return obj;
 	}
 };

--- a/lib/valid-object.js
+++ b/lib/valid-object.js
@@ -369,7 +369,7 @@ function validateSchema(obj, schema, names) {
 }
 
 // Two operation modes:
-// * Synchronous - done callback is not provided. will return the result object or throw error
+// * Synchronous - done callback is not provided. will return nothing or throw error
 // * Asynchronous - done callback is provided. will not throw error.
 //        will call callback with error as first parameter and object as second
 // Schema is expected to be validated.
@@ -384,7 +384,7 @@ module.exports = function(obj, schema, done) {
 		}
 	} catch(err) {
 		if (done) {
-			done(err, obj);
+			done(err);
 		} else {
 			throw err;
 		}

--- a/lib/valid-object.js
+++ b/lib/valid-object.js
@@ -216,6 +216,9 @@ function validateObject(obj, schema, names) {
 
 	if (schema.additionalProperties !== undefined) {
 		for (property in obj) {
+			if (schema.additionalProperties === 'remove' && schema.properties !== undefined && !(property in schema.properties)) {
+				delete obj[property];
+			}
 			if (schema.properties !== undefined && property in schema.properties) {
 				continue;
 			}
@@ -227,14 +230,6 @@ function validateObject(obj, schema, names) {
 				throw new Error('JSON object' + getName(names.concat([property])) + ' is not explicitly defined and therefore not allowed');
 			}
 			obj[property] = validateSchema(obj[property], schema.additionalProperties, names.concat([property]));
-		}
-	}
-
-	if (schema.sanitize !== undefined) {
-		for (property in obj) {
-			if (schema.properties !== undefined && !(property in schema.properties)) {
-				delete obj[property];
-			}
 		}
 	}
 

--- a/lib/valid-object.js
+++ b/lib/valid-object.js
@@ -369,7 +369,7 @@ function validateSchema(obj, schema, names) {
 }
 
 // Two operation modes:
-// * Synchronous - done callback is not provided. will return nothing or throw error
+// * Synchronous - done callback is not provided. will return JSON object or throw error
 // * Asynchronous - done callback is provided. will not throw error.
 //        will call callback with error as first parameter and object as second
 // Schema is expected to be validated.

--- a/lib/valid-object.js
+++ b/lib/valid-object.js
@@ -369,19 +369,13 @@ function validateSchema(obj, schema, names) {
 //        will call callback with error as first parameter and object as second
 // Schema is expected to be validated.
 module.exports = function(obj, schema, done) {
-	try {
-		validateSchema(obj, schema, []);
-	} catch(err) {
-		if (done) {
-			done(err);
-		} else {
-			throw err;
-		}
-	}
-	
-	if (done) {
-		done(null, obj);
-	} else {
-		return obj;
-	}
+    try {
+        validateSchema(obj, schema, []);
+    } catch(err) {
+        if (!done) {
+            throw err;
+        }
+        return done(err);
+    }
+    return done ? done(null, obj) : obj
 };

--- a/lib/valid-object.js
+++ b/lib/valid-object.js
@@ -230,6 +230,14 @@ function validateObject(obj, schema, names) {
 		}
 	}
 
+	if (schema.sanitize !== undefined) {
+		for (property in obj) {
+			if (schema.properties !== undefined && !(property in schema.properties)) {
+				delete obj[property];
+			}
+		}
+	}
+
 	if (schema.dependencies !== undefined) {
 		for (property in schema.dependencies) {
 			switch (getType(schema.dependencies[property])) {

--- a/lib/valid-object.js
+++ b/lib/valid-object.js
@@ -369,7 +369,7 @@ function validateSchema(obj, schema, names) {
 }
 
 // Two operation modes:
-// * Synchronous - done callback is not provided. will return nothing or throw error
+// * Synchronous - done callback is not provided. will return the result object or throw error
 // * Asynchronous - done callback is provided. will not throw error.
 //        will call callback with error as first parameter and object as second
 // Schema is expected to be validated.
@@ -379,10 +379,12 @@ module.exports = function(obj, schema, done) {
 
 		if (done) {
 			done(null, obj);
+		} else {
+			return obj;
 		}
 	} catch(err) {
 		if (done) {
-			done(err);
+			done(err, obj);
 		} else {
 			throw err;
 		}

--- a/lib/valid-schema.js
+++ b/lib/valid-schema.js
@@ -171,6 +171,8 @@ function validateObject(schema, names) {
 	if (schema.additionalProperties !== undefined) {
 		if (schema.additionalProperties === false) {
 			// ok
+		} else if (schema.additionalProperties === 'remove') {
+			//ok
 		} else if (!isOfType(schema.additionalProperties, 'object')) {
 			throwInvalidType(names, '\'additionalProperties\' attribute', schema.additionalProperties, 'either an object (schema) or false');
 		} else {

--- a/test/common.js
+++ b/test/common.js
@@ -98,7 +98,7 @@ exports.objectShouldBeInvalid = function (obj, schemaDef, options) {
 	return context;
 };
 
-exports.objectShouldBeSanitize = function (obj, schemaDef, objNested, options) {
+exports.objectShouldBeEquals = function (obj, objNested, schemaDef, options) {
 	var context = {
 		topic: function () {
 			var schema = createSchema(schemaDef);

--- a/test/common.js
+++ b/test/common.js
@@ -97,3 +97,20 @@ exports.objectShouldBeInvalid = function (obj, schemaDef, options) {
 	};
 	return context;
 };
+
+exports.objectShouldBeSanitize = function (obj, schemaDef, objNested, options) {
+	var context = {
+		topic: function () {
+			var schema = createSchema(schemaDef);
+			schema.validate(obj, this.callback);
+		}
+	};
+	var vow = (options && options.vow) || 'we got an error';
+	context[vow] = function (err, result) {
+		should.not.exist(err);
+		should.exist(result);
+		JSON.stringify(result).should.equal(JSON.stringify(objNested));
+		if (options && options.post) { options.post(err, result); }
+	};
+	return context;
+};

--- a/test/object-object-test.js
+++ b/test/object-object-test.js
@@ -5,7 +5,7 @@ var vows = require('vows');
 var common = require('./common'),
 	objectShouldBeValid = common.objectShouldBeValid,
 	objectShouldBeInvalid = common.objectShouldBeInvalid,
-	objectShouldBeSanitize = common.objectShouldBeSanitize;
+	objectShouldBeEquals = common.objectShouldBeEquals;
 
 var objNested = {
 	str: 'top',
@@ -109,12 +109,13 @@ var objAdditionalArray = {
 	extra: [42]
 };
 
-var objSanitize = {
+var objAdditionalPropertiesRemove = {
 	str: 'hi',
-	extra: 'discard data'
+	extra: 'discard data',
+	other: 'discard too'
 };
 
-var objNestedSanitize = {
+var objNestedAdditionalPropertiesRemove = {
 	str: 'hi'
 };
 
@@ -140,12 +141,12 @@ var schemaAdditionalPropertiesInteger = {
 	additionalProperties: { type: 'integer' }
 };
 
-var schemaSanitize = {
+var schemaAdditionalPropertiesRemove = {
 	type: 'object',
 	properties: {
 		str: { type: 'string' }
 	},
-	sanitize: true
+	additionalProperties: 'remove'
 };
 
 vows.describe('Object Object').addBatch({
@@ -158,5 +159,5 @@ vows.describe('Object Object').addBatch({
 	'when no additional properties is not respected': objectShouldBeInvalid(objAdditionalInteger, schemaNoAdditionalProperties, { errMsg: 'JSON object property \'extra\' is not explicitly defined and therefore not allowed' }),
 	'when additional property is correct type': objectShouldBeValid(objAdditionalInteger, schemaAdditionalPropertiesInteger),
 	'when additional property is wrong type': objectShouldBeInvalid(objAdditionalArray, schemaAdditionalPropertiesInteger, { errMsg: 'JSON object property \'extra\' is an array when it should be an integer' }),
-	'when sanitize is respected': objectShouldBeSanitize(objSanitize, schemaSanitize, objNestedSanitize)
+	'when additional property remove is respected': objectShouldBeEquals(objAdditionalPropertiesRemove, objNestedAdditionalPropertiesRemove, schemaAdditionalPropertiesRemove)
 }).export(module);

--- a/test/object-object-test.js
+++ b/test/object-object-test.js
@@ -4,7 +4,8 @@ var vows = require('vows');
 
 var common = require('./common'),
 	objectShouldBeValid = common.objectShouldBeValid,
-	objectShouldBeInvalid = common.objectShouldBeInvalid;
+	objectShouldBeInvalid = common.objectShouldBeInvalid,
+	objectShouldBeSanitize = common.objectShouldBeSanitize;
 
 var objNested = {
 	str: 'top',
@@ -108,6 +109,15 @@ var objAdditionalArray = {
 	extra: [42]
 };
 
+var objSanitize = {
+	str: 'hi',
+	extra: 'discard data'
+};
+
+var objNestedSanitize = {
+	str: 'hi'
+};
+
 var schemaNoAdditionalProperties = {
 	type: 'object',
 	properties: {
@@ -130,6 +140,14 @@ var schemaAdditionalPropertiesInteger = {
 	additionalProperties: { type: 'integer' }
 };
 
+var schemaSanitize = {
+	type: 'object',
+	properties: {
+		str: { type: 'string' }
+	},
+	sanitize: true
+};
+
 vows.describe('Object Object').addBatch({
 	'when nested object is valid': objectShouldBeValid(objNested, schemaNested),
 	'when nested object is missing a property': objectShouldBeInvalid(objNestedMissing, schemaNested, { errMsg: 'JSON object property \'obj1.obj2.obj3.str\' is required' }),
@@ -139,5 +157,6 @@ vows.describe('Object Object').addBatch({
 	'when no additional properties is respected': objectShouldBeValid(objNoAdditional, schemaNoAdditionalProperties),
 	'when no additional properties is not respected': objectShouldBeInvalid(objAdditionalInteger, schemaNoAdditionalProperties, { errMsg: 'JSON object property \'extra\' is not explicitly defined and therefore not allowed' }),
 	'when additional property is correct type': objectShouldBeValid(objAdditionalInteger, schemaAdditionalPropertiesInteger),
-	'when additional property is wrong type': objectShouldBeInvalid(objAdditionalArray, schemaAdditionalPropertiesInteger, { errMsg: 'JSON object property \'extra\' is an array when it should be an integer' })
+	'when additional property is wrong type': objectShouldBeInvalid(objAdditionalArray, schemaAdditionalPropertiesInteger, { errMsg: 'JSON object property \'extra\' is an array when it should be an integer' }),
+	'when sanitize is respected': objectShouldBeSanitize(objSanitize, schemaSanitize, objNestedSanitize)
 }).export(module);


### PR DESCRIPTION
This feature remove all non-matching properties from original JSON object.

How to use:
`additionalProperties: 'remove'`

See bellow:

```
// Schema
{
   str: { type: 'string' },
   additionalProperties: 'remove'
}
```

```
// Object
{
   str: 'hi',
   extra: 'unimportant data, discard this',
   extra1: 'discard this'
}
```

```
// Result object (after validate):
{
   str: 'hi'
}
```

```
// Getting result object
newObject = schema.validate(Object);

// or
schema.validate(Object, function(err, obj) {
   newObject = obj;
});
```

Obs.: I moved to new branch, because I needed merge my features in master.
